### PR TITLE
Make showcase submissions more safe

### DIFF
--- a/web/api_routes.py
+++ b/web/api_routes.py
@@ -266,20 +266,38 @@ def submit_build():
     try:
         os.makedirs(SHOWCASE_SUBMISSIONS_DIR, exist_ok=True)
 
+        # Stay safe with disk space
+        def _get_dir_size(path):
+            total = 0
+            for dirpath, _, filenames in os.walk(path):
+                for f in filenames:
+                    fp = os.path.join(dirpath, f)
+                    try:
+                        total += os.path.getsize(fp)
+                    except OSError:
+                        pass
+            return total
+
+        max_dir_size = 2 * 1024 * 1024 * 1024  # 2 GB in bytes
+        if _get_dir_size(SHOWCASE_SUBMISSIONS_DIR) >= max_dir_size:
+            log.error("Photo storage full. Rejecting submission.")
+            return jsonify({"error": "Photo storage full. Try again later."}), 507
+        
+        # Get form data
         photo_title = request.form.get("photo-title")
         photo_date = request.form.get("photo-date")
         photographer = request.form.get("photographer")
 
         # Validate form data
         if not photo_title or not photo_date or not photographer:
-            return jsonify({"error": "missing required form data"}), 400
+            return jsonify({"error": "Missing required form field"}), 400
 
         photo_file = request.files.get("photo-file")
         if not photo_file:
-            return jsonify({"error": "no file provided"}), 400
+            return jsonify({"error": "No file provided"}), 400
 
         if len(photo_file.read()) > 10 * 1024 * 1024:  # 10 MB limit
-            return jsonify({"error": "file size exceeds limit"}), 400
+            return jsonify({"error": "File size exceeds limit"}), 413
         photo_file.seek(0)
 
         # Clean the file name
@@ -313,10 +331,10 @@ def submit_build():
 
         log.info(f"Submission saved in folder: {folder_name}")
 
-        return jsonify({"message": "Submission successful"}), 200
+        return jsonify({"message": "Submission successful"}), 201
     except Exception:
         log.error(f"Error processing showcase submission: {traceback.format_exc()}")
-        return jsonify({"error": "internal error"}), 500
+        return jsonify({"error": "Internal error. Try again later."}), 500
     
 @api_routes.route("/api/showcase_manifest")
 def get_showcase_manifest():

--- a/web/js/showcase_submit.js
+++ b/web/js/showcase_submit.js
@@ -33,13 +33,17 @@ document.addEventListener("DOMContentLoaded", () => {
 
                 form.reset();
             } else {
+                sendingMessage.hidden = true;
+
                 return response.json().then(data => {
-                    throw new Error(data.message || "Failed to submit your photo. Please try again later.");
+                    // Use backend error field if available
+                    const errMsg = data.error || "Failed to submit your photo. Please try again later.";
+                    throw new Error(errMsg);
                 });
             }
         })
         .catch(error => {
-            alert(error.message);
+            alert("Error: " + error.message);
         })
         .finally(() => {
             submitButton.disabled = false;


### PR DESCRIPTION
This pull request adds disk space safety checks and improves error handling for the showcase photo submission API. The main changes include a new directory size limit to prevent storage overflow, more precise HTTP status codes for error responses, and better error messaging in both the backend and frontend.

**Disk space management:**
* Added a check in `submit_build()` (`web/api_routes.py`) to reject new photo submissions if the total size of the `SHOWCASE_SUBMISSIONS_DIR` exceeds 2 GB, returning a clear error message and a 507 status code.

**Error handling and status codes:**
* Updated error messages and HTTP status codes for missing form fields (now 400), missing files (now 400), and file size limits (now 413 instead of 400), with improved message clarity.
* Changed successful submission response to use status code 201 (Created) instead of 200, and standardized the internal error message and status code to 500.

**Frontend error messaging:**
* Improved frontend error handling in `showcase_submit.js` to display backend error messages for failed submissions, and clarified alert messages for users.